### PR TITLE
Bump MLflow from 3.6.0 to 3.10.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 graphviz==0.20.3
-mlflow==3.6.0
+mlflow==3.10.1
 pymc-marketing==0.17.1
 pytest==8.2.2


### PR DESCRIPTION
Closes #26

Co-authored-by: Isaac